### PR TITLE
Configure: Honor environment CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,8 @@ AC_CONFIG_HEADERS([config.h])
 # Checks for programs.
 AC_PROG_CC
 AC_LANG_C
-CFLAGS="-s -O2 -std=c99 -Wall -Wl,-export-dynamic"
+
+CFLAGS="-s -O2 -std=c99 -Wall -Wl,-export-dynamic $CFLAGS"
 
 # Checks for libraries.
 AC_ARG_ENABLE(gtk3, [AC_HELP_STRING([--enable-gtk3], [Compile against GTK 3.x explicitly])], [enable_gtk3=$enableval], [enable_gtk3="no"])


### PR DESCRIPTION
This allows (among others) Linux distro packages to set their own flags
according to their distro policy, e.g. for Mageia:
```
CFLAGS="-O2 -g -pipe -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fstack-protector --param=ssp-buffer-size=4"
```