### PR TITLE
This allows to use MEDNAFEN_HOME in mednaffe.

### DIFF
--- a/src/mednaffe.c
+++ b/src/mednaffe.c
@@ -638,8 +638,21 @@ want to select the file manually?\n", &gui);
   #ifdef G_OS_WIN32
     home = g_path_get_dirname(gui.binpath);
   #else
-    home = g_getenv ("HOME");
-    if (!home) home = g_get_home_dir();
+    /*
+     * If MEDNAFEN_HOME is set, then mednafen uses this
+     * location as root directory.
+     */
+    home = g_getenv ("MEDNAFEN_HOME");
+    if (!home)
+    {
+        /* g_get_home_dir() checks the value of HOME variable and,
+         * if needed, uses the value from the passwd database. */
+        const gchar *aux = NULL;
+        aux = g_get_home_dir();
+        /* Now append '/.mednafen' to get the default root location
+         * of mednafen. */
+        if (aux) home = g_strconcat(aux, "/.mednafen", NULL);
+    }
   #endif
     if (!home)
     {

--- a/src/toggles.c
+++ b/src/toggles.c
@@ -345,7 +345,7 @@ gchar* get_cfg(const gchar *home, guidata *gui)
   #ifdef G_OS_WIN32
     cfg_path = g_strconcat(home, "\\mednafen-09x.cfg", NULL);
   #else
-    cfg_path = g_strconcat(home, "/.mednafen/mednafen-09x.cfg", NULL);
+    cfg_path = g_strconcat(home, "/mednafen-09x.cfg", NULL);
   #endif
 
   if (g_file_test (cfg_path, G_FILE_TEST_IS_REGULAR))
@@ -357,7 +357,7 @@ Mednafen 09x configuration file found.\n", FE, gui);
   #ifdef G_OS_WIN32
     cfg_path = g_strconcat(home, "\\mednafen.cfg", NULL);
   #else
-    cfg_path = g_strconcat(home, "/.mednafen/mednafen.cfg", NULL);
+    cfg_path = g_strconcat(home, /mednafen.cfg", NULL);
   #endif
     if (g_file_test (cfg_path, G_FILE_TEST_IS_REGULAR))
       printf(" Mednafen 08x configuration file found\n");
@@ -410,7 +410,7 @@ gboolean check_version(gchar *stout, guidata *gui)
     GtkStatusbar *sbversion = GTK_STATUSBAR(gtk_builder_get_object(gui->builder, "sbversion"));
     gtk_statusbar_push(GTK_STATUSBAR(sbversion), 1, aline[0]);
 
-    gchar *tooltip = g_strconcat("Mednafen version detected: ",aline[0], "\nPath: ", gui->binpath, NULL);    
+    gchar *tooltip = g_strconcat("Mednafen version detected: ",aline[0], "\nPath: ", gui->binpath, NULL);
     gtk_widget_set_tooltip_text(GTK_WIDGET(sbversion), tooltip);
     g_free(tooltip);
 


### PR DESCRIPTION
Hey!

As explained in [1], mednafen uses the value of MEDNAFEN_HOME as its root directory when set.
Otherwise, It fallbacks to "HOME/.mednafen".
For some users (myself included), It is interesting to use this so we can have settings outside of HOME for a couple of reasons, like loading configs from USB or having less hidden files in HOME.

I am aware that we can change the mednafen dir with "HOME=/my/other/place ./mednaffe" and then creating a ".mednafen" in my-other-place, but since so few changes are needed to do the job, I decided to create this pull request.

Thanks for your attention! I’m looking forward to your reply!

[1] https://mednafen.github.io/documentation/#Section_base_directory