### PR TITLE
It uses MEDNAFEN_HOME as mednafen root directory when It is set.

### DIFF
--- a/src/mednaffe.c
+++ b/src/mednaffe.c
@@ -516,8 +516,7 @@ want to select the file manually?\n", &gui);
   #ifdef G_OS_WIN32
     home = g_path_get_dirname(gui.binpath);
   #else
-    home = g_getenv ("HOME");
-    if (!home) home = g_get_home_dir();
+    home = g_get_home_dir();
   #endif
     if (!home)
     {

--- a/src/toggles.c
+++ b/src/toggles.c
@@ -356,7 +356,13 @@ gchar* get_cfg(const gchar *home, guidata *gui)
   #ifdef G_OS_WIN32
     cfg_path = g_strconcat(home, "\\mednafen.cfg", NULL);
   #else
-    cfg_path = g_strconcat(home, "/.mednafen/mednafen.cfg", NULL);
+    /* Check if MEDNAFEN_HOME is set; if it is, then we use the path
+     * given as mednafen root directory. */
+    const gchar *mednafen_home =  g_getenv ("MEDNAFEN_HOME");
+    if (mednafen_home)
+        cfg_path = g_strconcat(mednafen_home, "/mednafen.cfg", NULL);
+    else
+        cfg_path = g_strconcat(home, "/.mednafen/mednafen.cfg", NULL);
   #endif
 
   if (g_file_test (cfg_path, G_FILE_TEST_IS_REGULAR))


### PR DESCRIPTION
Hey, I am back!

As we previously discussed, I opted for the solution where we check in **toggles.c** file if **MEDNAFEN_HOME** is set. If it is, we use; otherwise, uses **"$HOME/.mednafen/"**.

Another change I did was in file **mednafen.c**, where we set the **home** for non-windows; according to [1], **g-get-home-dir** already checks for HOME variable and, if unset, goes for the passwd database.

If you need anything, let me know! I did some testing so I believe everything should be fine!

Thanks again!

[1] https://developer.gnome.org/glib/stable/glib-Miscellaneous-Utility-Functions.html#g-get-home-dir