### PR TITLE
Fix joystick support on 32 bit linux

### DIFF
--- a/src/widgets/joystick_linux.c
+++ b/src/widgets/joystick_linux.c
@@ -220,7 +220,7 @@ init_joys (void)
     joy->num = js;
     joy->type = 1;
     joy->name = g_strndup (aname, strlen (aname));
-    joy->id = g_strdup_printf ("0x%016lx%04x%04x%08x", GetBVPV (number), num_axes, num_buttons, 0);
+    joy->id = g_strdup_printf ("0x%016"G_GINT64_MODIFIER"x%04x%04x%08x", GetBVPV (number), num_axes, num_buttons, 0);
     joy->data1 = GINT_TO_POINTER(fd);
 
     g_free (number);


### PR DESCRIPTION
The compiler warned about this:

```
widgets/joystick_linux.c: In function ‘init_joys’:
widgets/joystick_linux.c:223:40: warning: format ‘%lx’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘guint64’ {aka ‘long long unsigned int’} [-Wformat=]
  223 |     joy->id = g_strdup_printf ("0x%016lx%04x%04x%08x", GetBVPV (number), num_axes, num_buttons, 0);
      |                                   ~~~~~^               ~~~~~~~~~~~~~~~~
      |                                        |               |
      |                                        |               guint64 {aka long long unsigned int}
      |                                        long unsigned int
      |                                   %016llx
```