### PR TITLE
Fix failure to find mednafen.cfg when inside bin/ or lib/ folders on Windows

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,6 +41,7 @@ if LINUX
 else
 if WINDOWS
   mednaffe_SOURCES+= widgets/joystick_windows.c
+  mednaffe_SOURCES+= win32util.c win32util.h
   override CFLAGS +=-mwindows
   LIBS +=../share/win/mednaffe.res -ldxguid -ldinput
 else

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,8 +40,7 @@ if LINUX
   override CFLAGS +=-Wl,-export-dynamic
 else
 if WINDOWS
-  mednaffe_SOURCES+= widgets/joystick_windows.c
-  mednaffe_SOURCES+= win32util.c win32util.h
+  mednaffe_SOURCES+= win32util.c win32util.h widgets/joystick_windows.c
   override CFLAGS +=-mwindows
   LIBS +=../share/win/mednaffe.res -ldxguid -ldinput
 else

--- a/src/mainwindow.c
+++ b/src/mainwindow.c
@@ -41,6 +41,10 @@
 #include "preferences.h"
 #include "bios.h"
 
+#ifdef G_OS_WIN32
+  #include "win32util.h"
+#endif
+
 
 typedef struct _MainWindowClass MainWindowClass;
 typedef struct _MainWindowPrivate MainWindowPrivate;
@@ -381,7 +385,7 @@ main_window_process_exec_emu_ended (MedProcess* sender,
 
 #ifdef G_OS_WIN32
   gchar* string = NULL;
-  gchar* wpath = g_win32_get_package_installation_directory_of_module (NULL);
+  gchar* wpath = win32_get_process_directory ();
   gchar* txt = g_strconcat (wpath, "\\stdout.txt", NULL);
 
   if (g_file_get_contents(txt, &string, NULL, NULL))
@@ -713,7 +717,7 @@ main_window_save_settings (MainWindow* self)
   gint theme = gtk_combo_box_get_active (GTK_COMBO_BOX(priv->preferences->change_theme));
   g_key_file_set_integer (key, "GUI", "Theme", theme);
 
-  gchar* conf_path = g_win32_get_package_installation_directory_of_module (NULL);
+  gchar* conf_path = win32_get_process_directory ();
 #else
   gchar* conf_path = g_strconcat (g_get_user_config_dir (), "/mednaffe", NULL);
 
@@ -865,7 +869,7 @@ main_window_load_settings (MainWindow* self)
   GKeyFile *key = g_key_file_new ();
 
 #ifdef G_OS_WIN32
-  gchar* dir = g_win32_get_package_installation_directory_of_module (NULL);
+  gchar* dir = win32_get_process_directory ();
   gchar* conf_path = g_strconcat (dir, "\\mednaffe.conf", NULL);
   g_free(dir);
 #else

--- a/src/medprocess.c
+++ b/src/medprocess.c
@@ -28,12 +28,8 @@
 
 #ifdef G_OS_WIN32
   #include <windows.h>
+  #include "win32util.h"
 #endif
-
-#ifdef G_WITH_CYGWIN
-#include <sys/cygwin.h>
-#endif
-
 
 
 typedef struct _MedProcessClass MedProcessClass;
@@ -59,30 +55,6 @@ enum  {
 
 static guint med_process_signals[MED_PROCESS_NUM_SIGNALS] = {0};
 
-#ifdef G_OS_WIN32
-static gchar*
-win32_get_process_directory (void)
-{
-  wchar_t wpath[MAX_PATH];
-  if (!GetModuleFileNameW (NULL, wpath, MAX_PATH))
-    return NULL;
-
-  gchar* retval = g_utf16_to_utf8 (wpath, -1, NULL, NULL, NULL);
-
-  #ifdef G_WITH_CYGWIN
-  /* In Cygwin we need to have POSIX paths */
-  {
-    gchar tmp[MAX_PATH];
-
-    cygwin_conv_to_posix_path (retval, tmp);
-    g_free (retval);
-    retval = g_strdup (tmp);
-  }
-  #endif
-
-  return retval;
-}
-#endif
 
 static GFile*
 med_process_get_conf_path (MedProcess* self)

--- a/src/widgets/bios_helper.c
+++ b/src/widgets/bios_helper.c
@@ -24,6 +24,10 @@
 
 #include "bios_helper.h"
 
+#ifdef G_OS_WIN32
+  #include "win32util.h"
+#endif
+
 
 static const gchar*
 bios_get_value (GHashTable* table, const gchar* command)
@@ -52,7 +56,7 @@ bios_get_base_path (void)
   gchar* mh;
 
 #ifdef G_OS_WIN32
-  mh = g_win32_get_package_installation_directory_of_module (NULL);
+  mh = win32_get_process_directory ();
 
   if (mh == NULL)
     mh = g_strdup ("");

--- a/src/win32util.c
+++ b/src/win32util.c
@@ -1,0 +1,41 @@
+/*
+ * win32util.c
+ *
+ * Copyright 2013-2021 AmatCoder
+ *
+ * This file is part of Mednaffe.
+ *
+ * Mednaffe is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Mednaffe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Mednaffe; if not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+
+#include "win32util.h"
+
+#ifdef G_OS_WIN32
+
+#include <windows.h>
+
+gchar*
+win32_get_process_directory (void)
+{
+  wchar_t wpath[MAX_PATH];
+  if (!GetModuleFileNameW (NULL, wpath, MAX_PATH))
+    return NULL;
+
+  return g_utf16_to_utf8 (wpath, -1, NULL, NULL, NULL);
+}
+
+#endif

--- a/src/win32util.c
+++ b/src/win32util.c
@@ -23,10 +23,8 @@
 
 
 #include "win32util.h"
-
-#ifdef G_OS_WIN32
-
 #include <windows.h>
+
 
 gchar*
 win32_get_process_directory (void)
@@ -37,5 +35,3 @@ win32_get_process_directory (void)
 
   return g_utf16_to_utf8 (wpath, -1, NULL, NULL, NULL);
 }
-
-#endif

--- a/src/win32util.h
+++ b/src/win32util.h
@@ -25,16 +25,12 @@
 #ifndef __WIN32UTIL_H__
 #define __WIN32UTIL_H__
 
-#include <gtk/gtk.h>
-
-#ifdef G_OS_WIN32
+#include <glib.h>
 
 G_BEGIN_DECLS
 
 gchar* win32_get_process_directory (void);
 
 G_END_DECLS
-
-#endif
 
 #endif

--- a/src/win32util.h
+++ b/src/win32util.h
@@ -1,0 +1,40 @@
+/*
+ * win32util.h
+ *
+ * Copyright 2013-2021 AmatCoder
+ *
+ * This file is part of Mednaffe.
+ *
+ * Mednaffe is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Mednaffe is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Mednaffe; if not, see <http://www.gnu.org/licenses/>.
+ *
+ *
+ */
+
+
+#ifndef __WIN32UTIL_H__
+#define __WIN32UTIL_H__
+
+#include <gtk/gtk.h>
+
+#ifdef G_OS_WIN32
+
+G_BEGIN_DECLS
+
+gchar* win32_get_process_directory (void);
+
+G_END_DECLS
+
+#endif
+
+#endif


### PR DESCRIPTION
It seems from reading the code that the intent is to look in the process directory for mednafen.cfg.
`g_win32_get_package_installation_directory_of_module()` returns the parent directory when the path contains "bin" or "lib".

I switched out 
`g_win32_get_package_installation_directory_of_module(NULL)`
with new function 
`win32_get_process_directory()`
instead.

Resolves #129 